### PR TITLE
lint and format code before any commit

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "none",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false,
+  "fluid": false
+}

--- a/package.json
+++ b/package.json
@@ -73,12 +73,19 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run clean",
+      "pre-commit": "lint-staged && npm run clean",
       "after": "lint-staged",
       "then": "yarn precommit"
     }
   },
   "files": [
     "dist"
-  ]
+  ],
+  "lint-staged": {
+    "*.js": [
+      "npm run format",
+      "npm run lint",
+      "git add"
+    ]
+  }
 }


### PR DESCRIPTION
created a ".prettierrc" file same as "groceristar-fetch/.prettierrc" and enabled lint-staged for linting and formatting code before any commit 