### PR TITLE
Removed import/export of getHeaders and moved mainWrapper to a differ…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,6 @@
 // import { parseFoodComposition } from '../projects2.0/FoodComposition/parser';
-import path from 'path';
-
 import csvToJson from './csvToJson';
 
-// https://github.com/GroceriStar/food-datasets-csv-parser/issues/180
-import getHeaders from './getHeaders';
 import parseCsv from './parseCsv';
 
 // @TODO i don't like this name,
@@ -15,37 +11,10 @@ import parseDirectoryFiles from './fileSystem';
 
 // i adding utils here only because it's my guess
 import { readAllFiles, joinPath, getList } from './utils';
-
-const mainWrapper = async (filename) => {
-  const headers = await getHeaders(filename);
-
-  // console.log(headers);
-  // I might have to include lines 5-14 insinde of an async function and await it.
-  // This will become clearer once parseDrectoryFiles is functional.
-
-  // @TODO this line is a good idea. For all of our csv parsers
-  // projects we have a separated folder with files + parser inside.
-  // we can make a root directory as default inside of `parserDirectoryFiles`
-  // and change it if passed another variable
-  const directory = './';
-
-  const directoryPath = path.join(__dirname, directory + filename);
-
-  // test version
-  // const directoryPath = path.join(__dirname, filename);
-
-  // console.log(filename);
-
-  console.log(directoryPath);
-  console.log('---');
-  console.log(headers);
-  // parseDirectoryFiles(directoryPath, headers);
-  // parseDirectoryFiles(filename, headers);
-};
+import mainWrapper from './mainWrapper';
 
 export {
   csvToJson,
-  getHeaders,
   // @TODO let's debate should we export
   // parseCsv or we just using it inside of csvToJson
   parseCsv,

--- a/src/mainWrapper.js
+++ b/src/mainWrapper.js
@@ -1,8 +1,10 @@
 import path from 'path';
-import getHeaders from './getHeaders';
+// import getHeaders from './getHeaders';
+import csvToJson from './csvToJson';
+import parseCsv from './parseCsv';
 
 const mainWrapper = async (filename) => {
-    const headers = await getHeaders(filename);
+    // const headers = await getHeaders(filename);
   
     // console.log(headers);
     // I might have to include lines 5-14 insinde of an async function and await it.
@@ -12,20 +14,24 @@ const mainWrapper = async (filename) => {
     // projects we have a separated folder with files + parser inside.
     // we can make a root directory as default inside of `parserDirectoryFiles`
     // and change it if passed another variable
-    const directory = './';
+    // const directory = './';
   
-    const directoryPath = path.join(__dirname, directory + filename);
+    // const directoryPath = path.join(__dirname, directory + filename);
   
     // test version
     // const directoryPath = path.join(__dirname, filename);
   
     // console.log(filename);
   
-    console.log(directoryPath);
-    console.log('---');
-    console.log(headers);
+    // console.log(directoryPath);
+    // console.log('---');
+    // console.log(headers);
     // parseDirectoryFiles(directoryPath, headers);
     // parseDirectoryFiles(filename, headers);
+
+    const rawFilePath = path.join(__dirname, `Fish_Reftbl_RefDatasets.csv`);
+    const data = await parseCsv(rawFilePath);
+    await csvToJson(__dirname, data);
 };
 
 export {

--- a/src/mainWrapper.js
+++ b/src/mainWrapper.js
@@ -3,7 +3,7 @@ import path from 'path';
 import csvToJson from './csvToJson';
 import parseCsv from './parseCsv';
 
-const mainWrapper = async (filename) => {
+const mainWrapper = async (filename, dirPath) => {
     // const headers = await getHeaders(filename);
   
     // console.log(headers);
@@ -29,9 +29,9 @@ const mainWrapper = async (filename) => {
     // parseDirectoryFiles(directoryPath, headers);
     // parseDirectoryFiles(filename, headers);
 
-    const rawFilePath = path.join(__dirname, `Fish_Reftbl_RefDatasets.csv`);
+    const rawFilePath = path.join(dirPath, filename);
     const data = await parseCsv(rawFilePath);
-    await csvToJson(__dirname, data);
+    await csvToJson(dirPath, data);
 };
 
 export {

--- a/src/mainWrapper.js
+++ b/src/mainWrapper.js
@@ -1,0 +1,33 @@
+import path from 'path';
+import getHeaders from './getHeaders';
+
+const mainWrapper = async (filename) => {
+    const headers = await getHeaders(filename);
+  
+    // console.log(headers);
+    // I might have to include lines 5-14 insinde of an async function and await it.
+    // This will become clearer once parseDrectoryFiles is functional.
+  
+    // @TODO this line is a good idea. For all of our csv parsers
+    // projects we have a separated folder with files + parser inside.
+    // we can make a root directory as default inside of `parserDirectoryFiles`
+    // and change it if passed another variable
+    const directory = './';
+  
+    const directoryPath = path.join(__dirname, directory + filename);
+  
+    // test version
+    // const directoryPath = path.join(__dirname, filename);
+  
+    // console.log(filename);
+  
+    console.log(directoryPath);
+    console.log('---');
+    console.log(headers);
+    // parseDirectoryFiles(directoryPath, headers);
+    // parseDirectoryFiles(filename, headers);
+};
+
+export {
+    mainWrapper,
+}


### PR DESCRIPTION
## Proposed changes
It fixes the issue https://github.com/GroceriStar/food-datasets-csv-parser/issues/180. The following changes were made:
1. Moved the `mainWrapper` method to a separate file `mainWrapper.js`
2. Now, since `getHeaders` was not used directly anywhere, it's import/export has been removed from `index.js`. Although, `getHeaders` is still being imported in `mainWrapper.js` because the `mainWrapper` method uses `getHeaders`

## Types of changes

What types of changes does your code introduce to static food data?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules